### PR TITLE
Add rbenv version of the build phase script for compiling Sass

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -88,7 +88,7 @@ source /Users/${USER}/.rvm/environments/default
 ${GEM_HOME}/bin/sass ${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/default.scss ${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/default.css
 ```
 
-* If you're using rbenv, you should enter this code instead: 
+* If you're using rbenv, you should enter this instead: 
 
 ```
 /Users/${USER}/.rbenv/shims/sass ${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/default.scss ${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/default.css


### PR DESCRIPTION
Hey guys,

I added a script to compile .scss to .css using using sass with rbenv instead of RVM. Tested and working. As a lot of users are moving from RVM to rbenv i guess it's good practice to have both options.
