### PR TITLE
-[PXProxy isKindOfClass:]

### DIFF
--- a/src/Core/Styling/Utils/PXProxy.m
+++ b/src/Core/Styling/Utils/PXProxy.m
@@ -89,6 +89,12 @@
     return NO;
 }
 
+- (BOOL)isKindOfClass:(Class)aClass {
+    if ([self.overridingObject isKindOfClass:aClass]) return YES;
+    if ([self.baseObject isKindOfClass:aClass]) return YES;
+    return NO;
+}
+
 #pragma mark - hash and equality
 
 /// make sure we look like the original object


### PR DESCRIPTION
Had issues with code like `[self.tableView.dataSource isKindOfClass:whatever.class]`, PXProxy not implementing `isKindOfClass:`. So here is this small patch. Been using this for a while.
