### PR TITLE
Replace load method with initialize method

### DIFF
--- a/src/Core/Styling/Categories/UIView+PXStyling.m
+++ b/src/Core/Styling/Categories/UIView+PXStyling.m
@@ -149,8 +149,11 @@ static NSMutableArray *DYNAMIC_SUBCLASSES;
 
 #pragma mark - Dynamic subclassing initializer and property
 
-+ (void)load
++ (void)initialize
 {
+    if (self != UIView.class)
+        return;
+    
     @autoreleasepool
     {
 #ifdef PX_LOGGING

--- a/src/Modules/UIModule/Controls/PXMKAnnotationContainerView.m
+++ b/src/Modules/UIModule/Controls/PXMKAnnotationContainerView.m
@@ -32,8 +32,11 @@
 @implementation PXMKAnnotationContainerView
 
 /* DISABLED
-+ (void)load
++ (void)initialize
 {
+    if (self != PXMKAnnotationContainerView.class)
+        return;
+ 
     [UIView registerDynamicSubclass:self
                            forClass:[PXMKAnnotationContainerView targetSuperclass]
                     withElementName:@"annotation-container-view"];

--- a/src/Modules/UIModule/Controls/PXMKAnnotationView.m
+++ b/src/Modules/UIModule/Controls/PXMKAnnotationView.m
@@ -39,8 +39,11 @@
 
 @implementation PXMKAnnotationView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXMKAnnotationView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self
                            forClass:[PXMKAnnotationView targetSuperclass]
                     withElementName:@"annotation-view"];

--- a/src/Modules/UIModule/Controls/PXMKMapView.m
+++ b/src/Modules/UIModule/Controls/PXMKMapView.m
@@ -39,8 +39,11 @@
 
 @implementation PXMKMapView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXMKMapView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self
                            forClass:[PXMKMapView targetSuperclass]
                     withElementName:@"map-view"];

--- a/src/Modules/UIModule/Controls/PXMPVolumeView.m
+++ b/src/Modules/UIModule/Controls/PXMPVolumeView.m
@@ -34,8 +34,11 @@
 
 @implementation PXMPVolumeView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXMPVolumeView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self
                            forClass:[PXMPVolumeView targetSuperclass]
                     withElementName:@"volume-view"];

--- a/src/Modules/UIModule/Controls/PXUIActionSheet.m
+++ b/src/Modules/UIModule/Controls/PXUIActionSheet.m
@@ -37,8 +37,11 @@
 
 @implementation PXUIActionSheet
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIActionSheet.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"action-sheet"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIActivityIndicatorView.m
+++ b/src/Modules/UIModule/Controls/PXUIActivityIndicatorView.m
@@ -40,8 +40,11 @@
 
 @implementation PXUIActivityIndicatorView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIActivityIndicatorView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"activity-indicator-view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIButton.m
+++ b/src/Modules/UIModule/Controls/PXUIButton.m
@@ -69,8 +69,11 @@ static const char STYLE_CHILDREN;
 
 #pragma mark - Static methods
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIButton.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"button"];
 
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUICollectionView.m
+++ b/src/Modules/UIModule/Controls/PXUICollectionView.m
@@ -52,8 +52,11 @@ static const char PX_DATASOURCE_PROXY; // the proxy for the old datasource
 
 @implementation UICollectionView (PXFreestyle)
 
-+ (void)load
++ (void)initialize
 {
+    if (self != UICollectionView.class)
+        return;
+    
     [self swizzleMethod:@selector(setDelegate:) withMethod:@selector(px_setDelegate:)];
     [self swizzleMethod:@selector(setDataSource:) withMethod:@selector(px_setDataSource:)];
 
@@ -146,8 +149,11 @@ static const char PX_DATASOURCE_PROXY; // the proxy for the old datasource
 
 #pragma mark - Static load
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUICollectionView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"collection-view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUICollectionViewCell.m
+++ b/src/Modules/UIModule/Controls/PXUICollectionViewCell.m
@@ -49,8 +49,11 @@ static const char STYLE_CHILDREN;
 
 @implementation PXUICollectionViewCell
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUICollectionViewCell.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"collection-view-cell"];
 
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUIDatePicker.m
+++ b/src/Modules/UIModule/Controls/PXUIDatePicker.m
@@ -34,8 +34,11 @@
 
 @implementation PXUIDatePicker
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIDatePicker.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"date-picker"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIImageView.m
+++ b/src/Modules/UIModule/Controls/PXUIImageView.m
@@ -46,8 +46,11 @@ static NSDictionary *PSEUDOCLASS_MAP;
 
 @implementation PXUIImageView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIImageView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"image-view"];
 
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUILabel.m
+++ b/src/Modules/UIModule/Controls/PXUILabel.m
@@ -65,8 +65,11 @@ NSString *const kDefaultCacheLabelLineBreakMode = @"label.lineBreakMode";
 
 @implementation PXUILabel
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUILabel.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"label"];
 
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUILayoutContainerView.m
+++ b/src/Modules/UIModule/Controls/PXUILayoutContainerView.m
@@ -32,8 +32,11 @@
 @implementation PXUILayoutContainerView
 
 /* DISABLED
- + (void)load
+ + (void)initialize
 {
+    if (self != PXUILayoutContainerView.class)
+        return;
+ 
     [UIView registerDynamicSubclass:self
                            forClass:[PXUILayoutContainerView targetSuperclass]
                     withElementName:@"layout-container-view"];

--- a/src/Modules/UIModule/Controls/PXUINavigationBar.m
+++ b/src/Modules/UIModule/Controls/PXUINavigationBar.m
@@ -58,8 +58,11 @@ static NSDictionary *BUTTONS_PSEUDOCLASS_MAP;
 
 #pragma mark - Static methods
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUINavigationBar.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"navigation-bar"];
 
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUIPageControl.m
+++ b/src/Modules/UIModule/Controls/PXUIPageControl.m
@@ -42,8 +42,11 @@
 
 @implementation PXUIPageControl
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIPageControl.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"page-control"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIPickerView.m
+++ b/src/Modules/UIModule/Controls/PXUIPickerView.m
@@ -42,8 +42,11 @@
 
 @implementation PXUIPickerView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIPickerView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"picker-view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIProgressView.m
+++ b/src/Modules/UIModule/Controls/PXUIProgressView.m
@@ -42,8 +42,11 @@ static char const STYLE_CHILDREN;
 
 @implementation PXUIProgressView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIProgressView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"progress-view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIRefreshControl.m
+++ b/src/Modules/UIModule/Controls/PXUIRefreshControl.m
@@ -35,8 +35,11 @@
 
 @implementation PXUIRefreshControl
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIRefreshControl.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"refresh-control"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIScrollView.m
+++ b/src/Modules/UIModule/Controls/PXUIScrollView.m
@@ -41,8 +41,11 @@
 
 @implementation PXUIScrollView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIScrollView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"scroll-view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUISearchBar.m
+++ b/src/Modules/UIModule/Controls/PXUISearchBar.m
@@ -41,8 +41,11 @@
 
 @implementation PXUISearchBar
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUISearchBar.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"search-bar"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUISegmentedControl.m
+++ b/src/Modules/UIModule/Controls/PXUISegmentedControl.m
@@ -46,8 +46,11 @@ static char const STYLE_CHILDREN;
 
 @implementation PXUISegmentedControl
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUISegmentedControl.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"segmented-control"];
 
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUISlider.m
+++ b/src/Modules/UIModule/Controls/PXUISlider.m
@@ -48,8 +48,11 @@ static NSDictionary *PSEUDOCLASS_MAP;
 
 #pragma mark - Static methods
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUISlider.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"slider"];
     
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUIStepper.m
+++ b/src/Modules/UIModule/Controls/PXUIStepper.m
@@ -45,8 +45,11 @@ static char const STYLE_CHILDREN;
 
 @implementation PXUIStepper
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIStepper.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"stepper"];
     
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUISwitch.m
+++ b/src/Modules/UIModule/Controls/PXUISwitch.m
@@ -47,8 +47,11 @@ static char const STYLE_CHILDREN;
 
 @implementation PXUISwitch
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUISwitch.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"switch"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUITabBar.m
+++ b/src/Modules/UIModule/Controls/PXUITabBar.m
@@ -46,8 +46,11 @@
 
 @implementation PXUITabBar
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUITabBar.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"tab-bar"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUITableView.m
+++ b/src/Modules/UIModule/Controls/PXUITableView.m
@@ -52,8 +52,11 @@ static const char PX_DELEGATE_PROXY; // the proxy for the old delegate
 
 @implementation UITableView (PXFreestyle)
 
-+ (void)load
++ (void)initialize
 {
+    if (self != UITableView.class)
+        return;
+    
     [self swizzleMethod:@selector(setDelegate:) withMethod:@selector(px_setDelegate:)];
     
     // Cache this value
@@ -143,8 +146,11 @@ static const char PX_DELEGATE_PROXY; // the proxy for the old delegate
 
 @implementation PXUITableView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUITableView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"table-view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUITableViewCell.m
+++ b/src/Modules/UIModule/Controls/PXUITableViewCell.m
@@ -71,8 +71,11 @@ static const char DETAIL_TEXT_LABEL_BACKGROUND_SET;
 
 @implementation PXUITableViewCell
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUITableViewCell.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"table-view-cell"];
     
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUITableViewCellContentView.m
+++ b/src/Modules/UIModule/Controls/PXUITableViewCellContentView.m
@@ -32,8 +32,11 @@
 @implementation PXUITableViewCellContentView
 
 /* DISABLED
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUITableViewCellContentView.class)
+        return;
+ 
     [UIView registerDynamicSubclass:self
                      forClass:[PXUITableViewCellContentView targetSuperclass]
                     withElementName:@"table-view-cell-content"];

--- a/src/Modules/UIModule/Controls/PXUITableViewHeaderFooterView.m
+++ b/src/Modules/UIModule/Controls/PXUITableViewHeaderFooterView.m
@@ -51,8 +51,11 @@ static NSDictionary *LABEL_PSEUDOCLASS_MAP;
 
 @implementation PXUITableViewHeaderFooterView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUITableViewHeaderFooterView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"table-view-headerfooter-view"];
     
     LABEL_PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUITextField.m
+++ b/src/Modules/UIModule/Controls/PXUITextField.m
@@ -95,8 +95,11 @@ static char PADDING;
 
 static NSDictionary *PSEUDOCLASS_MAP;
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUITextField.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"text-field"];
 
     PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUITextView.m
+++ b/src/Modules/UIModule/Controls/PXUITextView.m
@@ -48,8 +48,11 @@ static const char STYLE_CHILDREN;
 
 @implementation PXUITextView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUITextView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"text-view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIToolbar.m
+++ b/src/Modules/UIModule/Controls/PXUIToolbar.m
@@ -50,8 +50,11 @@ static NSDictionary *BUTTONS_PSEUDOCLASS_MAP;
 
 @implementation PXUIToolbar
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIToolbar.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"toolbar"];
     
     BUTTONS_PSEUDOCLASS_MAP = @{

--- a/src/Modules/UIModule/Controls/PXUIView.m
+++ b/src/Modules/UIModule/Controls/PXUIView.m
@@ -47,8 +47,11 @@ static const char STYLE_CHILDREN;
 
 @implementation PXUIView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIWebView.m
+++ b/src/Modules/UIModule/Controls/PXUIWebView.m
@@ -35,8 +35,11 @@
 
 @implementation PXUIWebView
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIWebView.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"web-view"];
 }
 

--- a/src/Modules/UIModule/Controls/PXUIWindow.m
+++ b/src/Modules/UIModule/Controls/PXUIWindow.m
@@ -33,8 +33,11 @@
 
 @implementation PXUIWindow
 
-+ (void)load
++ (void)initialize
 {
+    if (self != PXUIWindow.class)
+        return;
+    
     [UIView registerDynamicSubclass:self withElementName:@"window"];
 }
 

--- a/src/Modules/UIModule/Controls/Virtual/UIBarButtonItem+PXStyling.m
+++ b/src/Modules/UIModule/Controls/Virtual/UIBarButtonItem+PXStyling.m
@@ -63,8 +63,11 @@ void PXForceLoadUIBarButtonItemPXStyling() {}
 @dynamic isVirtualControl;
 @dynamic pxStyleParent;
 
-+ (void)load
++ (void)initialize
 {
+    if (self != UIBarButtonItem.class)
+        return;
+    
     BUTTONS_PSEUDOCLASS_MAP = @{
                                 @"normal"      : @(UIControlStateNormal),
                                 @"highlighted" : @(UIControlStateHighlighted),

--- a/src/Modules/UIModule/Controls/Virtual/UIBarItem+PXStyling.m
+++ b/src/Modules/UIModule/Controls/Virtual/UIBarItem+PXStyling.m
@@ -48,8 +48,11 @@ void PXForceLoadUIBarItemPXStyling() {}
 @dynamic pxStyleParent;
 @dynamic pxStyleChildren;
 
-+ (void)load
++ (void)initialize
 {
+    if (self != UIBarItem.class)
+        return;
+    
     // Set default styling mode to 'normal' (i.e. stylable)
     [[UIBarItem appearance] setStyleMode:PXStylingNormal];
 }

--- a/src/Modules/UIModule/Controls/Virtual/UITabBarItem+PXStyling.m
+++ b/src/Modules/UIModule/Controls/Virtual/UITabBarItem+PXStyling.m
@@ -45,8 +45,11 @@ void PXForceLoadUITabBarItemPXStyling() {}
 
 static NSDictionary *PSEUDOCLASS_MAP;
 
-+ (void)load
++ (void)initialize
 {
+    if (self != UITabBarItem.class)
+        return;
+    
     PSEUDOCLASS_MAP = @{
         @"normal" : @(UIControlStateNormal),
         @"selected" : @(UIControlStateHighlighted),


### PR DESCRIPTION
Methods replaced to make postponed initialization, not upon class load,
but after explicit initializePixateFreestyle method call.
It is necessary for postponed UI load for background application
started with 'voip' flag.
