### PR TITLE
fix retain cycle between PXStylesheetParser and PSStylesheetLexer

### DIFF
--- a/src/Core/Styling/Parsing/PXStylesheetLexer.h
+++ b/src/Core/Styling/Parsing/PXStylesheetLexer.h
@@ -55,7 +55,7 @@
 /**
  *  A delegate to call when various events occur within the lexer
  */
-@property (nonatomic, strong) id<PXStylesheetLexerDelegate> delegate;
+@property (nonatomic, weak) id<PXStylesheetLexerDelegate> delegate;
 
 /**
  *  Initializer a new instance with the specified source value


### PR DESCRIPTION
fix memory leak detectable by Instruments by using weak delegate reference

```
#   Type    Details Graph
24   PXStylesheetParser - 2 nodes   Simple Cycle     
      <PXStylesheetParser 0x118e4a460>       
      lexer_    PXStylesheetLexer*  [Strong]     
      <PXStylesheetLexer 0x118e4a4a0>        
      _delegate id <PXStylesheetLexerDelegate>  [Strong]     
      <PXStylesheetParser 0x118e4a460>       
```
