### PR TITLE
Real Podspec with source code

### DIFF
--- a/PixateFreestyle.podspec
+++ b/PixateFreestyle.podspec
@@ -26,12 +26,16 @@ Pod::Spec.new do |s|
   }
   s.author       = { "Pixate" => "info@pixate.com" }
   s.platform     = :ios, '5.0'
-  s.source       = { :git => "https://github.com/anton-matosov/pixate-freestyle-ios.git", :tag => "2.1.4" }
+  s.source       = {
+        :git => "https://github.com/anton-matosov/pixate-freestyle-ios.git",
+        :tag => "2.1.4",
+        :submodules => true
+  }
 
   s.default_subspec = 'All'
   s.subspec 'All' do |ss|
     ss.prefix_header_file = "src/pixate-freestyle-Prefix.pch"
-    ss.source_files = 'src/PixateFreestyle.{h,m}', "src/Version.h", 'src/Core/**/*.{h,m}', 'src/Modules/**/*.{h,m}', 'src/Kernel/Categories/*.{h,m}', 'src/Kernel/Utils/*.{h,c}', 'submodules/pixate-expression-machine/src/ExpressionMachine/**/*.{h,m,lm}', 'submodules/pixate-expression-machine/src/ExpressionMachine/**/**/*.{h,m,lm}'
+    ss.source_files = 'src/PixateFreestyle.{h,m}', "src/Version.h", 'src/Core/**/*.{h,m}', 'src/Modules/**/*.{h,m}', 'src/Kernel/Categories/*.{h,m}', 'src/Kernel/Utils/*.{h,c}', 'submodules/pixate-expression-machine/src/ExpressionMachine/**/*.{h,m,lm}'
     ss.requires_arc = true
     ss.dependency 'PixateFreestyle/MAFuture'
   end

--- a/PixateFreestyle.podspec
+++ b/PixateFreestyle.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
              LICENSE
   }
   s.author       = { "Pixate" => "info@pixate.com" }
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '5.0'
   s.source       = { :git => "https://github.com/anton-matosov/pixate-freestyle-ios.git", :tag => "2.1.4" }
 
   s.default_subspec = 'All'

--- a/PixateFreestyle.podspec
+++ b/PixateFreestyle.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PixateFreestyle"
-  s.version      = "2.1.5"
+  s.version      = "2.1.4"
   s.summary      = "Style your iOS app with CSS, using 100% native code and no webviews."
   s.description  = <<-DESC
                    Pixate is an iOS framework that allows you to style your application using stylesheets and a CSS-like syntax. Pixate lets you build  beautiful applications with less code and more flexibility by using familiar CSS markup to style native controls and components. Free up your team to focus on creating amazing user experiences throughout the design and development cycle.
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   }
   s.author       = { "Pixate" => "info@pixate.com" }
   s.platform     = :ios, '8.0'
-  s.source       = { :git => "https://github.com/anton-matosov/pixate-freestyle-ios.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/anton-matosov/pixate-freestyle-ios.git", :tag => "2.1.4" }
   # s.source_files = 'src/PixateFreestyle.{h,m}', "src/Version.h", 'src/Core/**/*.{h,m}', 'src/Modules/**/*.{h,m}', 'src/Kernel/**/*.{h,m}', 'submodules/pixate-expression-machine/src/ExpressionMachine/**/*.{h,m}'
   s.requires_arc = false
   s.resource = "src/Framework/Resources/Info.plist"

--- a/PixateFreestyle.podspec
+++ b/PixateFreestyle.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PixateFreestyle"
-  s.version      = "2.1.1"
+  s.version      = "2.1.5"
   s.summary      = "Style your iOS app with CSS, using 100% native code and no webviews."
   s.description  = <<-DESC
                    Pixate is an iOS framework that allows you to style your application using stylesheets and a CSS-like syntax. Pixate lets you build  beautiful applications with less code and more flexibility by using familiar CSS markup to style native controls and components. Free up your team to focus on creating amazing user experiences throughout the design and development cycle.
@@ -25,11 +25,11 @@ Pod::Spec.new do |s|
              LICENSE
   }
   s.author       = { "Pixate" => "info@pixate.com" }
-  s.platform     = :ios, '5.0'
-  s.source       = { :http => "https://github.com/Pixate/pixate-freestyle-ios/releases/download/v#{s.version}/PixateFreestyle.framework.zip" }
-  s.source_files = 'PixateFreestyle.framework/Versions/A/Headers/*.h'
-  s.preserve_paths = 'PixateFreestyle.framework'
-  s.frameworks = 'CoreText', 'QuartzCore', 'UIKit', 'CoreGraphics', 'PixateFreestyle'
-  s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/PixateFreestyle"' }
+  s.platform     = :ios, '8.0'
+  s.source       = { :git => "https://github.com/anton-matosov/pixate-freestyle-ios.git", :tag => "master" }
+  # s.source_files = 'src/PixateFreestyle.{h,m}', "src/Version.h", 'src/Core/**/*.{h,m}', 'src/Modules/**/*.{h,m}', 'src/Kernel/**/*.{h,m}', 'submodules/pixate-expression-machine/src/ExpressionMachine/**/*.{h,m}'
+  s.requires_arc = false
+  s.resource = "src/Framework/Resources/Info.plist"
+  s.frameworks = 'CoreText', 'QuartzCore', 'UIKit', 'CoreGraphics'
   #s.prepare_command = 'open "http://www.pixate.com/docs/framework/ios/latest/getting-started/index.html#app_setup" || true'
 end

--- a/PixateFreestyle.podspec
+++ b/PixateFreestyle.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.author       = { "Pixate" => "info@pixate.com" }
   s.platform     = :ios, '5.0'
   s.source       = {
-        :git => "https://github.com/anton-matosov/pixate-freestyle-ios.git",
+        :git => "https://github.com/Pixate/pixate-freestyle-ios.git",
         :tag => "2.1.4",
         :submodules => true
   }

--- a/PixateFreestyle.podspec
+++ b/PixateFreestyle.podspec
@@ -27,8 +27,21 @@ Pod::Spec.new do |s|
   s.author       = { "Pixate" => "info@pixate.com" }
   s.platform     = :ios, '8.0'
   s.source       = { :git => "https://github.com/anton-matosov/pixate-freestyle-ios.git", :tag => "2.1.4" }
-  # s.source_files = 'src/PixateFreestyle.{h,m}', "src/Version.h", 'src/Core/**/*.{h,m}', 'src/Modules/**/*.{h,m}', 'src/Kernel/**/*.{h,m}', 'submodules/pixate-expression-machine/src/ExpressionMachine/**/*.{h,m}'
-  s.requires_arc = false
+
+  s.default_subspec = 'All'
+  s.subspec 'All' do |ss|
+    ss.prefix_header_file = "src/pixate-freestyle-Prefix.pch"
+    ss.source_files = 'src/PixateFreestyle.{h,m}', "src/Version.h", 'src/Core/**/*.{h,m}', 'src/Modules/**/*.{h,m}', 'src/Kernel/Categories/*.{h,m}', 'src/Kernel/Utils/*.{h,c}',  'submodules/pixate-expression-machine/src/ExpressionMachine/**/*.{h,m,lm}'
+    ss.requires_arc = true
+    ss.dependency 'PixateFreestyle/MAFuture'
+  end
+
+  s.subspec 'MAFuture' do |ss|
+    ss.prefix_header_file = "src/pixate-freestyle-Prefix.pch"
+    ss.source_files = 'src/Kernel/Third-Party/MAFuture/*.{h,m}'
+    ss.requires_arc = false
+  end
+
   s.resource = "src/Framework/Resources/Info.plist"
   s.frameworks = 'CoreText', 'QuartzCore', 'UIKit', 'CoreGraphics'
   #s.prepare_command = 'open "http://www.pixate.com/docs/framework/ios/latest/getting-started/index.html#app_setup" || true'

--- a/PixateFreestyle.podspec
+++ b/PixateFreestyle.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'All'
   s.subspec 'All' do |ss|
     ss.prefix_header_file = "src/pixate-freestyle-Prefix.pch"
-    ss.source_files = 'src/PixateFreestyle.{h,m}', "src/Version.h", 'src/Core/**/*.{h,m}', 'src/Modules/**/*.{h,m}', 'src/Kernel/Categories/*.{h,m}', 'src/Kernel/Utils/*.{h,c}',  'submodules/pixate-expression-machine/src/ExpressionMachine/**/*.{h,m,lm}'
+    ss.source_files = 'src/PixateFreestyle.{h,m}', "src/Version.h", 'src/Core/**/*.{h,m}', 'src/Modules/**/*.{h,m}', 'src/Kernel/Categories/*.{h,m}', 'src/Kernel/Utils/*.{h,c}', 'submodules/pixate-expression-machine/src/ExpressionMachine/**/*.{h,m,lm}', 'submodules/pixate-expression-machine/src/ExpressionMachine/**/**/*.{h,m,lm}'
     ss.requires_arc = true
     ss.dependency 'PixateFreestyle/MAFuture'
   end
@@ -42,7 +42,6 @@ Pod::Spec.new do |s|
     ss.requires_arc = false
   end
 
-  s.resource = "src/Framework/Resources/Info.plist"
   s.frameworks = 'CoreText', 'QuartzCore', 'UIKit', 'CoreGraphics'
   #s.prepare_command = 'open "http://www.pixate.com/docs/framework/ios/latest/getting-started/index.html#app_setup" || true'
 end

--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -92,11 +92,11 @@ function xcode_build_target() {
     || die "XCode build failed for platform: ${1}."
 }
 
-xcode_build_target "iphonesimulator7.1" "${BUILDCONFIGURATION}" "i386" "6.1" "i386"
-xcode_build_target "iphonesimulator7.1" "${BUILDCONFIGURATION}" "x86_64" "7.0" "x86_64"
-xcode_build_target "iphoneos7.1" "${BUILDCONFIGURATION}" "armv7" "6.1" "Arm"
-xcode_build_target "iphoneos7.1" "${BUILDCONFIGURATION}" "armv7s" "6.1" "Arm7S"
-xcode_build_target "iphoneos7.1" "${BUILDCONFIGURATION}" "arm64" "7.0" "Arm64"
+xcode_build_target "iphonesimulator" "${BUILDCONFIGURATION}" "i386" "6.1" "i386"
+xcode_build_target "iphonesimulator" "${BUILDCONFIGURATION}" "x86_64" "7.0" "x86_64"
+xcode_build_target "iphoneos" "${BUILDCONFIGURATION}" "armv7" "6.1" "Arm"
+xcode_build_target "iphoneos" "${BUILDCONFIGURATION}" "armv7s" "6.1" "Arm7S"
+xcode_build_target "iphoneos" "${BUILDCONFIGURATION}" "arm64" "7.0" "Arm64"
 
 # -----------------------------------------------------------------------------
 # Merge lib files for different platforms into universal binary

--- a/src/Core/Styling/Shapes/PXBoxModel.m
+++ b/src/Core/Styling/Shapes/PXBoxModel.m
@@ -39,6 +39,7 @@
 }
 
 @synthesize bounds = _bounds;
+@synthesize padding = _padding;
 
 #pragma mark - Initializers
 

--- a/src/Kernel/Third-Party/MAFuture/MABaseFuture.m
+++ b/src/Kernel/Third-Party/MAFuture/MABaseFuture.m
@@ -7,6 +7,7 @@
 
 - (id)init
 {
+    self = [super init];
     _lock = [[NSCondition alloc] init];
     return self;
 }


### PR DESCRIPTION
Updated podspec to include source code instead of pre-compiled framework which allows to debug and use any custom build settings include bitcode and easy rebuilds with latest SDKs.

Tested only with `use_frameworks!`
