### PR TITLE
Fix for #186. Implemented custom responds to selector that works fine with x64 simulators on iOS 9

### DIFF
--- a/src/Kernel/Categories/NSObject+PXSubclass.m
+++ b/src/Kernel/Categories/NSObject+PXSubclass.m
@@ -145,6 +145,7 @@ static BOOL respondsToSelectorRAW(id self, SEL selector)
     return NO;
 }
 
+#if (TARGET_IPHONE_SIMULATOR && TARGET_CPU_X86_64)
 static BOOL classHierarchyRespondsToSelector(Class class, SEL selector)
 {
     if (class)
@@ -161,6 +162,7 @@ static BOOL classHierarchyRespondsToSelector(Class class, SEL selector)
 
     return NO;
 }
+#endif
 
 static BOOL respondsToSelectorIMP(id self, SEL _cmd, SEL selector)
 {


### PR DESCRIPTION
Fixes #186
