### PR TITLE
Removed Herokuapp 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can build the style of your app piece-by-piece using the method above. For e
 
 ## Mailing List & Twitter
 
-Keep up with notifications and announcements by joining Pixate's [mailing list](http://pixatesurvey.herokuapp.com) and [follow us](http://twitter.com/PixateFreestyle) on Twitter.
+Keep up with notifications and announcements by joining Pixate's mailing list and [follow us](http://twitter.com/PixateFreestyle) on Twitter.
 
 ## Docs
 


### PR DESCRIPTION
The herokuapp mentioned in the Repo was expired and was vulnerable to a domain takeover..I managed to takeover the domain http://pixatesurvey.herokuapp.com  

Just let me know if you want to own the domain again..I can remove it from my Heroku profile so you can reclaim it again